### PR TITLE
Add Travis CI and tweak dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 .git
 client_secret.json
+bin
+tests
+.travis.yml
+phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: php
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+before_script:
+  - composer install --no-interaction
+
+script:
+  - bin/phpunit
+


### PR DESCRIPTION
Configuration for running tests on Travis CI is added; I hope that the outcome will be more tests 😃 
Currently, it runs on 7, 7.1 and 7.2. When the Dockerfile version will be more specific (as it should be) we could run only single PHP version that docker image is using.

Enabling Travis CI from one of the members is needed of course.

Besides of that, I added unnecessary files from image build by adding them to `.dockerignore`.